### PR TITLE
fix websocket oauth

### DIFF
--- a/ibind/client/ibkr_ws_client.py
+++ b/ibind/client/ibkr_ws_client.py
@@ -318,8 +318,8 @@ class IbkrWsClient(WsClient):
             _LOGGER.warning(f'Acquiring session cookie failed, connection to the Gateway may be broken.')
             return None
         session_id = status.data['session']
-        payload = {'session': session_id}
-        return f'api={json.dumps(payload)}'
+        # payload = {'session': session_id}
+        return f'api={session_id}'
 
     def get_header(self):
         return {'User-Agent': 'ClientPortalGW/1'} if self._use_oauth else None

--- a/ibind/client/ibkr_ws_client.py
+++ b/ibind/client/ibkr_ws_client.py
@@ -318,8 +318,10 @@ class IbkrWsClient(WsClient):
             _LOGGER.warning(f'Acquiring session cookie failed, connection to the Gateway may be broken.')
             return None
         session_id = status.data['session']
-        # payload = {'session': session_id}
-        return f'api={session_id}'
+        if self._use_oauth:
+            return f'api={session_id}'
+        payload = {'session': session_id}
+        return f'api={json.dumps(payload)}'
 
     def get_header(self):
         return {'User-Agent': 'ClientPortalGW/1'} if self._use_oauth else None


### PR DESCRIPTION
This pull request fixes the malformed session cookie in the websocket connection and allows a persistent connection to be correctly established with the 'ClientPortalGW/1' user agent.